### PR TITLE
Fixed an issue where the rating would increase excessively when I beat an opponent with a higher rating than me.

### DIFF
--- a/Lib9c/Battle/ArenaScoreHelper.cs
+++ b/Lib9c/Battle/ArenaScoreHelper.cs
@@ -47,7 +47,7 @@ namespace Nekoyume.Battle
             var differ = challengerRating - defenderRating;
             if (differ < 0)
             {
-                foreach (var pair in CachedScore.Where(pair => pair.Key < 0).OrderBy(kv => kv.Key))
+                foreach (var pair in CachedScore.Where(pair => pair.Key < 0).OrderByDescending(kv => kv.Key))
                 {
                     if (differ < pair.Key)
                     {


### PR DESCRIPTION
Fixed an issue where the rating would increase excessively when I beat an opponent with a higher rating than me.


Step to reproduce:

```
public class Program
{
	public static void Main()
	{
		const int MyRating = 1000;
		
		for (var OpponentRating = 800; OpponentRating < 1800; OpponentRating += 20) {
			Console.WriteLine("MyRating\t" + MyRating + "\tOpponent:\t" + OpponentRating + "\tScore Earned:\t" + ArenaScoreHelper.GetScore(MyRating, OpponentRating));
		}
	}
}
```

```
MyRating    1000    Opponent:    800    Score Earned:    4
MyRating    1000    Opponent:    820    Score Earned:    8
MyRating    1000    Opponent:    840    Score Earned:    8
MyRating    1000    Opponent:    860    Score Earned:    8
MyRating    1000    Opponent:    880    Score Earned:    8
MyRating    1000    Opponent:    900    Score Earned:    8
MyRating    1000    Opponent:    920    Score Earned:    15
MyRating    1000    Opponent:    940    Score Earned:    15
MyRating    1000    Opponent:    960    Score Earned:    15
MyRating    1000    Opponent:    980    Score Earned:    15
MyRating    1000    Opponent:    1000    Score Earned:    15
MyRating    1000    Opponent:    1020    Score Earned:    60
MyRating    1000    Opponent:    1040    Score Earned:    60
MyRating    1000    Opponent:    1060    Score Earned:    60
MyRating    1000    Opponent:    1080    Score Earned:    60
MyRating    1000    Opponent:    1100    Score Earned:    60
MyRating    1000    Opponent:    1120    Score Earned:    60
MyRating    1000    Opponent:    1140    Score Earned:    60
```